### PR TITLE
Refactor core tools to use LangChain BaseTool

### DIFF
--- a/.cursor/rules.md
+++ b/.cursor/rules.md
@@ -41,6 +41,7 @@
 - **LLM client**: Use `cogents.common.llm.get_llm_client` via a helper in `alithia/core/llm_utils.py`.
 - **Provider**: Default to OpenAI provider; model configurable via profile/config.
 - **Usage**: Generate answers/summaries using `llm.generate(messages=[...])` with system/user roles.
+- **Tools**: Do not implement a custom tool base class. All tools must subclass `langchain_core.tools.BaseTool` and declare a `args_schema` pydantic model for inputs. Optional `execute()` helpers are allowed for internal usage.
 
 ### Configuration and Environment
 

--- a/alithia/core/tools/__init__.py
+++ b/alithia/core/tools/__init__.py
@@ -1,4 +1,4 @@
-from .base import Tool, ToolInput, ToolOutput
+from .base import BaseTool, ToolInput, ToolOutput
 from .models import (
     StructuredPaper,
     PaperMetadata,
@@ -12,7 +12,7 @@ from .models import (
 )
 
 __all__ = [
-    "Tool",
+    "BaseTool",
     "ToolInput",
     "ToolOutput",
     "StructuredPaper",

--- a/alithia/core/tools/base.py
+++ b/alithia/core/tools/base.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional
-
 from pydantic import BaseModel
+
+# Re-export LangChain BaseTool to ensure ecosystem compatibility
+from langchain_core.tools import BaseTool as BaseTool
 
 
 class ToolInput(BaseModel):
@@ -12,29 +12,3 @@ class ToolInput(BaseModel):
 
 class ToolOutput(BaseModel):
     """Base class for tool output models."""
-
-
-class Tool(ABC):
-    """Abstract base class for tools with a simple execute interface."""
-
-    name: str
-    description: str
-
-    def __init__(self, name: Optional[str] = None, description: str = "") -> None:
-        self.name = name or self.__class__.__name__
-        self.description = description
-
-    @abstractmethod
-    def execute(self, inputs: ToolInput, **kwargs: Any) -> ToolOutput:
-        """Run the tool and return structured output."""
-        raise NotImplementedError
-
-    # Helper to allow dict input in integration contexts
-    def __call__(self, inputs: ToolInput | Dict[str, Any], **kwargs: Any) -> ToolOutput:
-        if isinstance(inputs, dict):
-            # Attempt to coerce dict into the tool's input model via type hints
-            model_cls = getattr(self, "InputModel", None)
-            if model_cls is None:
-                raise TypeError("Tool is missing InputModel type for dict invocation.")
-            inputs = model_cls(**inputs)
-        return self.execute(inputs, **kwargs)

--- a/tests/integration/test_tools_integration.py
+++ b/tests/integration/test_tools_integration.py
@@ -20,7 +20,7 @@ def test_pdf_parser_integration(monkeypatch):
 
     tool = PDFParserTool()
     monkeypatch.setattr(tool, "processor", DummyPDFProcessor())
-    out = tool(PDFParserInput(file_path="/tmp/sample.pdf"))
+    out = tool.execute(PDFParserInput(file_path="/tmp/sample.pdf"))
     assert out.structured_paper.sections
 
 
@@ -46,7 +46,7 @@ def test_web_searcher_integration(monkeypatch):
     monkeypatch.setattr(ws.arxiv, "Search", lambda query, max_results=5: types.SimpleNamespace())
 
     tool = WebSearcherTool()
-    out = tool(FindPaperInfoInput(title="Foo"))
+    out = tool.execute(FindPaperInfoInput(title="Foo"))
     assert out.pdf_url and out.metadata
 
 
@@ -65,7 +65,7 @@ def test_reference_linker_integration(monkeypatch):
         bibliography=[BibliographyEntry(ref_id="[1]", full_citation="Ref")],
     )
     tool = ReferenceLinkerTool(embedding_service=DummyEmbeddingService())
-    out = tool(ReferenceLinkerInput(source_paper=paper, query="topic"))
+    out = tool.execute(ReferenceLinkerInput(source_paper=paper, query="topic"))
     assert out.references
 
 
@@ -81,5 +81,5 @@ def test_code_generator_integration(monkeypatch):
 
     paper = StructuredPaper(paper_id="p", sections=[Section(section_number="1", title="t", content=[])])
     tool = CodeGeneratorTool()
-    out = tool(CodeGeneratorInput(pseudocode_element={"pseudocode": "x"}, source_paper=paper))
+    out = tool.execute(CodeGeneratorInput(pseudocode_element={"pseudocode": "x"}, source_paper=paper))
     assert "print" in out.generated_code

--- a/tests/unit/test_tools_base.py
+++ b/tests/unit/test_tools_base.py
@@ -1,6 +1,6 @@
 import pytest
 
-from alithia.core.tools.base import Tool, ToolInput, ToolOutput
+from alithia.core.tools.base import BaseTool, ToolInput, ToolOutput
 
 
 class EchoInput(ToolInput):
@@ -11,16 +11,21 @@ class EchoOutput(ToolOutput):
     text: str
 
 
-class EchoTool(Tool):
-    InputModel = EchoInput
+class EchoTool(BaseTool):
+    name: str = "test.echo"
+    description: str = "Echo back provided text"
+    args_schema = EchoInput
 
     def execute(self, inputs: EchoInput, **kwargs):
         return EchoOutput(text=inputs.text)
 
+    def _run(self, text: str) -> EchoOutput:  # type: ignore[override]
+        return self.execute(EchoInput(text=text))
 
-def test_tool_execute_and_call():
+
+def test_tool_execute_and_invoke():
     tool = EchoTool()
     out = tool.execute(EchoInput(text="hello"))
     assert out.text == "hello"
-    out2 = tool({"text": "world"})
+    out2 = tool.invoke({"text": "world"})
     assert out2.text == "world"


### PR DESCRIPTION
Refactor core tools to use `langchain_core.tools.BaseTool` for LangChain ecosystem compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-5294e9d8-56cb-4bfb-ad7d-4f2a377d2a99">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5294e9d8-56cb-4bfb-ad7d-4f2a377d2a99">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

